### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/aiw-devops/8eaa80ac-e000-4a6b-94e2-c8486aeb81b0/e5fb297a-5280-4277-b97b-c078bdb456bd/_apis/work/boardbadge/b48136b5-116c-44fb-85f6-0d1987fda0dc)](https://dev.azure.com/aiw-devops/8eaa80ac-e000-4a6b-94e2-c8486aeb81b0/_boards/board/t/e5fb297a-5280-4277-b97b-c078bdb456bd/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#32](https://dev.azure.com/aiw-devops/8eaa80ac-e000-4a6b-94e2-c8486aeb81b0/_workitems/edit/32). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.